### PR TITLE
Fix for Open/Close Door Status Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,6 @@ LiftMasterAccessory.prototype = {
                 var thisAttributeSet = device.Attributes[j];
                 if (thisAttributeSet.AttributeDisplayName == "desc") {
                   thisDoorName = thisAttributeSet.Value;
-                  break;
                 }
                 if (thisAttributeSet.AttributeDisplayName == "doorstate") {
                   thisDoorState = thisAttributeSet.Value;


### PR DESCRIPTION
For my specific setup (Chamberlain opener with separate MyQ hub), the Open/Close status of the door would always return closed. I narrowed it down to a "break" command that was exiting the loop through the attributes that in my data set had not yet reached the "doorstate" attribute. This was forcing my door to always assume the default status of 2 which is closed. By removing the break, the code now correctly returns my status.

Maybe on other configurations door status always comes before "desc", but not for me.

I assume the break was entered for efficiency, but it was simply occurring too soon for my setup.
